### PR TITLE
Mention generic-hand-select

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -127,7 +127,7 @@ The "[=hand-tracking=]" [=feature descriptor=] should only be granted for an {{X
 Physical Hand Input Sources {#physical-hand}
 ===========================
 
-An {{XRInputSource}} is a <dfn>physical hand input source</dfn> if it tracks a physical hand. A [=physical hand input sources=] <dfn>supports hand tracking</dfn> if it supports reporting the poses of one or more [=skeleton joint=]s defined in this specification.
+An {{XRInputSource}} is a <dfn>physical hand input source</dfn> if it tracks a physical hand. A [=physical hand input source=] <dfn>supports hand tracking</dfn> if it supports reporting the poses of one or more [=skeleton joint=]s defined in this specification.
 
 [=Physical hand input sources=] MUST include the [=XRInputSource/input profile name=] of "generic-hand-select" in their {{XRInputSource/profile}}.
 

--- a/index.bs
+++ b/index.bs
@@ -129,7 +129,7 @@ Physical Hand Input Sources {#physical-hand}
 
 An {{XRInputSource}} is a <dfn>physical hand input source</dfn> if it tracks a physical hand. A [=physical hand input sources=] <dfn>supports hand tracking</dfn> if it supports reporting the poses of one or more [=skeleton joint=]s defined in this specification.
 
-[=Physical hand input sources=] SHOULD include the [=XRInputSource/input profile name=] of "generic-hand-select" in their {{XRInputSource/profile}}.
+[=Physical hand input sources=] MUST include the [=XRInputSource/input profile name=] of "generic-hand-select" in their {{XRInputSource/profile}}.
 
 XRInputSource {#xrinputsource-interface}
 -------------

--- a/index.bs
+++ b/index.bs
@@ -95,6 +95,7 @@ spec: webxr-1;
     type: dfn; text: session; for: XRFrame
     type: dfn; text: time; for: XRFrame
     type: dfn; text: session; for: XRSpace
+    type: dfn; text: input profile name; for: XRInputSource
 spec:infra; type:dfn; text:list
 </pre>
 
@@ -127,6 +128,8 @@ Physical Hand Input Sources {#physical-hand}
 ===========================
 
 An {{XRInputSource}} is a <dfn>physical hand input source</dfn> if it tracks a physical hand. A [=physical hand input sources=] <dfn>supports hand tracking</dfn> if it supports reporting the poses of one or more [=skeleton joint=]s defined in this specification.
+
+[=Physical hand input sources=] SHOULD include the [=XRInputSource/input profile name=] of "generic-hand-select" in their {{XRInputSource/profile}}.
 
 XRInputSource {#xrinputsource-interface}
 -------------


### PR DESCRIPTION
Pairs with https://github.com/immersive-web/webxr-input-profiles/pull/170

We can change this if there are ever hand input sources that do not support select. For now it doesn't matter too much.


r? @cabanier


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr-hand-input/pull/30.html" title="Last updated on Jul 23, 2020, 11:22 PM UTC (06e415f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-hand-input/30/cb7e1d6...Manishearth:06e415f.html" title="Last updated on Jul 23, 2020, 11:22 PM UTC (06e415f)">Diff</a>