### PR TITLE
Add a simple hand diagram

### DIFF
--- a/images/hand-layout.svg
+++ b/images/hand-layout.svg
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="103.19381mm"
+   height="142.44547mm"
+   viewBox="0 0 103.19381 142.44547"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="hand-layout.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2"
+     inkscape:cx="356.52402"
+     inkscape:cy="137.81118"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2487"
+     inkscape:window-height="2054"
+     inkscape:window-x="-10"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-19.051913,-14.697116)">
+    <path
+       style="fill:#dde3e3;fill-opacity:1;stroke:#000000;stroke-width:0.56179392;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 69.829289,156.2881 C 67.622086,147.7283 65.437313,139.1749 61.666905,130.16848 54.033453,127.08624 46.858915,118.49704 39.67143,110.06324 37.124563,104.85077 34.652244,99.638293 29.876569,94.425827 26.97689,89.059356 23.318141,84.007985 19.480269,79.260976 c -1.100835,-4.986587 4.004241,-6.857484 8.591983,-5.885509 4.587743,0.971982 9.601895,5.936681 12.458375,9.880779 3.27762,2.87997 6.104982,6.210194 8.935663,9.537104 0.852117,-5.430578 4.201437,-9.273762 4.210072,-19.847483 -1.713006,-6.043027 -3.09847,-12.086054 -4.124153,-18.129082 -1.0401,-4.63967 -1.816097,-9.279341 -1.718395,-13.919011 -0.653475,-4.910653 -0.528102,-12.055 0.558479,-15.078931 1.08658,-3.023929 5.038735,-3.969505 7.303185,-1.546556 2.264448,2.422949 3.270451,9.66472 3.909352,14.219731 1.031037,4.138679 2.062075,8.118387 3.093114,12.028777 1.407579,3.994538 2.757671,7.414197 4.38191,13.575332 1.772553,1.752351 3.577545,1.806469 4.381912,-1.031038 -0.297798,-5.363677 -0.720878,-10.75241 0.08592,-15.895167 -0.383255,-6.311726 0.997119,-10.859818 1.632477,-16.152928 0.619805,-4.611031 1.748609,-11.1762 3.264952,-13.833093 1.516344,-2.656894 8.446503,-3.454145 9.107505,0.687359 0.661,4.141503 -0.237507,8.834579 -0.343682,13.747172 -0.106174,4.912592 0.126725,10.711338 -0.171838,16.067008 0.02318,5.06927 -0.280955,10.13854 -0.945119,15.20781 0.454911,1.143819 0.201181,3.941127 2.577594,0.601438 1.002397,-3.637273 2.0048,-7.274545 3.007196,-10.911818 0.796506,-4.730999 2.01901,-9.036005 3.264951,-13.317573 0.815017,-4.582391 1.663872,-11.266738 3.35087,-13.790132 2.355898,-3.523919 8.644958,-2.31775 9.150468,1.632477 0.61002,4.766945 -0.68521,9.784842 -1.33176,14.133811 l -1.89024,16.582527 c -1.50534,4.29599 -2.590028,8.591982 -3.179029,12.887974 0.290711,2.697592 0.598548,5.354682 3.350869,2.233913 1.01193,-2.882309 2.19109,-4.992935 3.4368,-7.217264 1.61556,-3.397789 2.98007,-5.093981 4.38191,-8.334223 1.40183,-3.240241 2.51028,-8.044868 4.63967,-10.739978 2.1294,-2.695111 6.75298,-1.870901 7.04542,2.319835 0.29244,4.190737 -0.36141,8.684493 -1.89023,12.802055 -1.05183,3.361271 -2.63648,6.988948 -4.12415,10.568137 -1.06941,3.140662 -2.31156,6.10859 -3.60864,9.021585 -0.36021,4.957737 -1.57669,9.701408 -2.83536,14.434532 -0.99996,7.014594 -2.30451,14.003814 -6.01438,20.792594 0.237,2.95386 0.22112,5.78127 0,8.50606 1.52178,7.87599 3.66483,15.75197 6.1003,23.62796 -9.943329,6.5759 -22.880636,9.45924 -39.694951,7.56094 z"
+       id="path4531"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccczccccczzcccccczzzcccccssccccczzzcccccccc" />
+    <g
+       id="g5217"
+       transform="matrix(0.64947272,0,0,0.64947272,6.6782156,5.1517418)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5170"
+         d="m 25.664583,110.20417 15.478125,16.53645 16.933333,24.07709 c 0,0 28.707291,24.07708 59.531249,48.15416 L 98.028125,160.60729 85.460416,107.55833 76.464583,69.722918 72.098958,47.762501 l -1.984375,-15.875"
+         style="fill:none;stroke:#000000;stroke-width:2.56500006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:5.13000018, 2.56500009;stroke-dashoffset:0;stroke-opacity:0.4679803" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         id="path5170-9"
+         d="m 144.54696,33.247229 -3.37912,18.269898 -4.55667,22.820722 -6.63653,39.005011 -4.38644,43.30301 -7.98091,42.326 -5.99317,-41.96669 -1.97362,-51.36561 0.65005,-42.65823 2.42195,-26.331339 1.71979,-15.742708"
+         style="fill:none;stroke:#000000;stroke-width:2.56500006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:5.13000024, 2.56500012;stroke-dashoffset:0;stroke-opacity:0.4679803" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="path5170-9-4"
+         d="m 172.24536,66.40326 -4.43745,14.168856 -7.46709,16.470723 -11.92819,29.347721 -12.45624,34.70405 -18.3491,37.87726"
+         style="fill:none;stroke:#000000;stroke-width:2.56500006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:5.1300003, 2.56500015;stroke-dashoffset:0;stroke-opacity:0.4679803" />
+    </g>
+    <g
+       id="g4551"
+       transform="matrix(0.64947272,0,0,0.64947272,6.6782156,5.1517418)">
+      <circle
+         r="8.8635416"
+         cy="199.36876"
+         cx="117.87187"
+         id="path4539"
+         style="opacity:1;fill:#adacac;fill-opacity:1;stroke-width:0.26458332" />
+      <text
+         id="text4543"
+         y="201.75"
+         x="115.35833"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="201.75"
+           x="115.35833"
+           id="tspan4541"
+           sodipodi:role="line"><tspan
+             style="font-size:7.05555534px"
+             id="tspan4586">0</tspan></tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,-13.360569,-11.001192)"
+       id="g4551-5">
+      <circle
+         r="5.4239583"
+         cy="199.36876"
+         cx="117.87187"
+         id="path4539-0"
+         style="opacity:1;fill:#00ac00;fill-opacity:1;stroke-width:0.16190919" />
+      <text
+         id="text4543-3"
+         y="201.75"
+         x="115.62292"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="201.75"
+           x="115.62292"
+           id="tspan4541-5"
+           sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4580">1</tspan> <tspan
+   id="tspan4545-4"
+   style="font-size:3.52777767px" /></tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,-32.081584,-26.380841)"
+       id="g4551-5-4">
+      <circle
+         r="5.4239583"
+         cy="199.36876"
+         cx="117.87187"
+         id="path4539-0-6"
+         style="opacity:1;fill:#00ac00;fill-opacity:1;stroke-width:0.16190919" />
+      <text
+         id="text4543-3-5"
+         y="201.75"
+         x="115.62292"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="201.75"
+           x="115.62292"
+           id="tspan4541-5-8"
+           sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4618">2</tspan> <tspan
+   id="tspan4545-4-9"
+   style="font-size:3.52777767px" /></tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,-43.37243,-41.932329)"
+       id="g4551-5-4-6">
+      <circle
+         r="5.4239583"
+         cy="199.36876"
+         cx="117.87187"
+         id="path4539-0-6-7"
+         style="opacity:1;fill:#00ac00;fill-opacity:1;stroke-width:0.16190919" />
+      <text
+         id="text4543-3-5-0"
+         y="201.75"
+         x="115.62292"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="201.75"
+           x="115.62292"
+           id="tspan4541-5-8-8"
+           sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4618-9">3</tspan> <tspan
+   id="tspan4545-4-9-8"
+   style="font-size:3.52777767px" /></tspan></text>
+      <circle
+         r="5.4239583"
+         cy="182.9646"
+         cx="102.83057"
+         id="path4539-0-6-7-8"
+         style="opacity:1;fill:#00ac00;fill-opacity:1;stroke-width:0.16190919" />
+      <text
+         id="text4543-3-5-0-9"
+         y="185.34584"
+         x="100.58162"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="185.34584"
+           x="100.58162"
+           id="tspan4541-5-8-8-4"
+           sodipodi:role="line"><tspan
+   style="font-size:7.05555534px;stroke-width:0.26458332"
+   id="tspan4618-9-7">4</tspan> <tspan
+   id="tspan4545-4-9-8-0"
+   style="font-size:3.52777767px;stroke-width:0.26458332" /></tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,-6.1337951,-19.850934)"
+       id="g4551-5-9">
+      <circle
+         r="5.4239583"
+         cy="199.36876"
+         cx="117.87187"
+         id="path4539-0-8"
+         style="opacity:1;fill:#484aff;fill-opacity:1;stroke-width:0.16190919" />
+      <text
+         id="text4543-3-3"
+         y="201.75"
+         x="115.62292"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="201.75"
+           x="115.62292"
+           id="tspan4541-5-85"
+           sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4580-8">5</tspan> <tspan
+   id="tspan4545-4-3"
+   style="font-size:3.52777767px" /></tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,-14.28622,-54.218866)"
+       id="g4551-5-9-3">
+      <circle
+         r="5.4239583"
+         cy="199.36876"
+         cx="117.87187"
+         id="path4539-0-8-7"
+         style="opacity:1;fill:#484aff;fill-opacity:1;stroke-width:0.16190919" />
+      <text
+         id="text4543-3-3-8"
+         y="201.75"
+         x="115.62292"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="201.75"
+           x="115.62292"
+           id="tspan4541-5-85-4"
+           sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4580-8-4">6</tspan> <tspan
+   id="tspan4545-4-3-0"
+   style="font-size:3.52777767px" /></tspan></text>
+      <g
+         transform="translate(-9.1281249,-37.703124)"
+         id="g4551-5-9-0">
+        <circle
+           r="5.4239583"
+           cy="199.36876"
+           cx="117.87187"
+           id="path4539-0-8-1"
+           style="opacity:1;fill:#484aff;fill-opacity:1;stroke-width:0.16190919" />
+        <text
+           id="text4543-3-3-7"
+           y="201.75"
+           x="115.62292"
+           style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.26458332"
+             y="201.75"
+             x="115.62292"
+             id="tspan4541-5-85-6"
+             sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4580-8-9">7</tspan> <tspan
+   id="tspan4545-4-3-3"
+   style="font-size:3.52777767px" /></tspan></text>
+        <g
+           transform="translate(-4.233333,-22.621875)"
+           id="g4551-5-9-8">
+          <circle
+             r="5.4239583"
+             cy="199.36876"
+             cx="117.87187"
+             id="path4539-0-8-75"
+             style="opacity:1;fill:#484aff;fill-opacity:1;stroke-width:0.16190919" />
+          <text
+             id="text4543-3-3-6"
+             y="201.75"
+             x="115.62292"
+             style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             xml:space="preserve"><tspan
+               style="stroke-width:0.26458332"
+               y="201.75"
+               x="115.62292"
+               id="tspan4541-5-85-0"
+               sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4580-8-44">8</tspan> <tspan
+   id="tspan4545-4-3-31"
+   style="font-size:3.52777767px" /></tspan></text>
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,-24.252921,-103.36501)"
+       id="g4551-5-9-9">
+      <circle
+         r="5.4239583"
+         cy="199.36876"
+         cx="117.87187"
+         id="path4539-0-8-3"
+         style="opacity:1;fill:#484aff;fill-opacity:1;stroke-width:0.16190919" />
+      <text
+         id="text4543-3-3-5"
+         y="201.75"
+         x="115.62292"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="201.75"
+           x="115.62292"
+           id="tspan4541-5-85-2"
+           sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4580-8-7">9</tspan> <tspan
+   id="tspan4545-4-3-03"
+   style="font-size:3.52777767px" /></tspan></text>
+    </g>
+    <g
+       id="g5001"
+       transform="matrix(0.64947272,0,0,0.64947272,6.6782156,5.1517418)">
+      <g
+         id="g4551-5-9-89"
+         transform="translate(-5.4239557,-42.730217)">
+        <g
+           id="g4875">
+          <circle
+             r="5.4239583"
+             cy="199.36876"
+             cx="117.3427"
+             id="path4539-0-8-0"
+             style="opacity:1;fill:#e70000;fill-opacity:1;stroke-width:0.16190919" />
+          <text
+             id="text4543-3-3-9"
+             y="201.75"
+             x="112.7125"
+             style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             xml:space="preserve"><tspan
+               style="stroke-width:0.26458332"
+               y="201.75"
+               x="112.7125"
+               id="tspan4541-5-85-1"
+               sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4580-8-6">10</tspan> <tspan
+   id="tspan4545-4-3-07"
+   style="font-size:3.52777767px" /></tspan></text>
+        </g>
+        <g
+           id="g4875-2"
+           transform="translate(-2.5135417,-51.196875)">
+          <circle
+             r="5.4239583"
+             cy="199.36876"
+             cx="117.87187"
+             id="path4539-0-8-0-8"
+             style="opacity:1;fill:#e70000;fill-opacity:1;stroke-width:0.16190919" />
+          <text
+             id="text4543-3-3-9-0"
+             y="201.75"
+             x="113.24167"
+             style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             xml:space="preserve"><tspan
+               style="stroke-width:0.26458332"
+               y="201.75"
+               x="113.24167"
+               id="tspan4541-5-85-1-0"
+               sodipodi:role="line"><tspan
+   style="font-size:7.05555534px"
+   id="tspan4580-8-6-6">11</tspan> </tspan></text>
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,1.9526267,-83.431609)"
+       id="g4875-23">
+      <circle
+         style="opacity:1;fill:#e70000;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-6"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-1"><tspan
+           sodipodi:role="line"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"
+           id="tspan4929"><tspan
+   id="tspan4580-8-6-64"
+   style="font-size:7.05555534px">12</tspan> </tspan></text>
+      <g
+         transform="translate(1.984375,-25.929163)"
+         id="g4875-6">
+        <circle
+           style="opacity:1;fill:#e70000;fill-opacity:1;stroke-width:0.16190919"
+           id="path4539-0-8-0-7"
+           cx="117.87187"
+           cy="199.36876"
+           r="5.4239583" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+           x="113.24167"
+           y="201.75"
+           id="text4543-3-3-9-7"><tspan
+             sodipodi:role="line"
+             id="tspan4541-5-85-1-3"
+             x="113.24167"
+             y="201.75"
+             style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-7"
+   style="font-size:7.05555534px">13</tspan> </tspan></text>
+        <g
+           transform="translate(2.1166666,-16.271875)"
+           id="g4875-67">
+          <circle
+             style="opacity:1;fill:#e70000;fill-opacity:1;stroke-width:0.16190919"
+             id="path4539-0-8-0-67"
+             cx="117.87187"
+             cy="199.36876"
+             r="5.4239583" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             x="113.24167"
+             y="201.75"
+             id="text4543-3-3-9-2"><tspan
+               sodipodi:role="line"
+               x="113.24167"
+               y="201.75"
+               style="stroke-width:0.26458332"
+               id="tspan4967"><tspan
+   id="tspan4580-8-6-3"
+   style="font-size:7.05555534px">14</tspan> </tspan></text>
+        </g>
+      </g>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,10.888289,-21.99893)"
+       id="g4875-1">
+      <circle
+         style="opacity:1;fill:#e728e5;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0"
+   style="font-size:7.05555534px">15</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,14.496922,-50.524313)"
+       id="g4875-1-1">
+      <circle
+         style="opacity:1;fill:#e728e5;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-9"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-9"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-3"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-2"
+   style="font-size:7.05555534px">16</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,19.050673,-75.784743)"
+       id="g4875-1-7">
+      <circle
+         style="opacity:1;fill:#e728e5;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-0"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-5"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-5"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-8"
+   style="font-size:7.05555534px">17</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,22.315626,-90.99255)"
+       id="g4875-1-0">
+      <circle
+         style="opacity:1;fill:#e728e5;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-1"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-0"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-1"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-5"
+   style="font-size:7.05555534px">18</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,24.291782,-102.5058)"
+       id="g4875-1-2">
+      <circle
+         style="opacity:1;fill:#e728e5;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-15"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-7"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-6"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-20"
+   style="font-size:7.05555534px">19</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,18.621074,-19.507254)"
+       id="g4875-1-16">
+      <circle
+         style="opacity:1;fill:#e0ed00;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-07"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-6"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-31"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-0"
+   style="font-size:7.05555534px">20</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,26.353858,-42.533768)"
+       id="g4875-1-16-3">
+      <circle
+         style="opacity:1;fill:#e0ed00;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-07-6"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-6-3"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-31-4"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-0-9"
+   style="font-size:7.05555534px">21</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,34.172562,-61.350212)"
+       id="g4875-1-16-9">
+      <circle
+         style="opacity:1;fill:#e0ed00;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-07-5"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-6-2"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-31-6"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-0-0"
+   style="font-size:7.05555534px">22</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,39.069993,-71.832429)"
+       id="g4875-1-16-5">
+      <circle
+         style="opacity:1;fill:#e0ed00;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-07-66"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-6-6"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-31-5"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-0-1"
+   style="font-size:7.05555534px">23</tspan> </tspan></text>
+    </g>
+    <g
+       transform="matrix(0.64947272,0,0,0.64947272,41.733507,-81.025852)"
+       id="g4875-1-16-8">
+      <circle
+         style="opacity:1;fill:#e0ed00;fill-opacity:1;stroke-width:0.16190919"
+         id="path4539-0-8-0-9-07-62"
+         cx="117.87187"
+         cy="199.36876"
+         r="5.4239583" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="113.24167"
+         y="201.75"
+         id="text4543-3-3-9-16-6-60"><tspan
+           sodipodi:role="line"
+           id="tspan4541-5-85-1-08-31-68"
+           x="113.24167"
+           y="201.75"
+           style="stroke-width:0.26458332"><tspan
+   id="tspan4580-8-6-0-0-18"
+   style="font-size:7.05555534px">24</tspan> </tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:6.8735857px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.17183965"
+       x="21.542345"
+       y="8.2482395"
+       id="text5304"><tspan
+         sodipodi:role="line"
+         id="tspan5302"
+         x="21.542345"
+         y="14.51922"
+         style="stroke-width:0.17183965" /></text>
+  </g>
+</svg>

--- a/index.bs
+++ b/index.bs
@@ -194,8 +194,7 @@ This specification defines the following [=skeleton joints=]:
 </tbody>
 </table>
 
-
-TODO: Add diagram
+<img src="images/hand-layout.svg" alt="Visual aid demonstrating joint layout">
 
 XRHand {#xrhand-interface}
 ------


### PR DESCRIPTION
Given that there's a sudden surge of interest in this spec thanks to Oculus, figured it could use a simple diagram to spruce things up. 😁 (Also, I wished I had this when looking at some Three.js code recently.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-hand-input/pull/35.html" title="Last updated on Jul 27, 2020, 11:14 PM UTC (611c181)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-hand-input/35/c8a2340...611c181.html" title="Last updated on Jul 27, 2020, 11:14 PM UTC (611c181)">Diff</a>