### PR TITLE
allow UAs to not surface hand controllers unless hand tracking is requested

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -125,6 +125,9 @@ by this module as a new valid [=feature descriptor=] for articulated hand tracki
 
 The "[=hand-tracking=]" [=feature descriptor=] should only be granted for an {{XRSession}} its [=XRSession/XR device=] has [=physical hand input sources=] that [=supports hand tracking=].
 
+The user agent MAY gate support for hand based {{XRInputSource|XRInputSources}} based upon this [=feature descriptor=].
+
+NOTE: This means that if an {{XRSession}} does not request the "[=hand-tracking=]" [=feature descriptor=], the user agent may choose to not support input controllers that are hand based.
 
 Physical Hand Input Sources {#physical-hand}
 ===========================


### PR DESCRIPTION
closes #51


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/webxr-hand-input/pull/52.html" title="Last updated on Sep 23, 2020, 6:49 PM UTC (2cb18b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-hand-input/52/f23c91e...cabanier:2cb18b0.html" title="Last updated on Sep 23, 2020, 6:49 PM UTC (2cb18b0)">Diff</a>