### PR TITLE
Remove redundant checks in getJointPose and fillPoses

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -341,8 +341,6 @@ When this method is invoked, the user agent MUST run the following steps:
 
   1. Let |frame| be [=this=].
   1. Let |session| be |frame|'s {{XRFrame/session}} object.
-  1. If |frame|'s [=active=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
-  1. If |baseSpace|'s [=XRSpace/session=] or |joint|'s [=XRSpace/session=] are different from [=this=] {{XRFrame/session}}, throw an {{InvalidStateError}} and abort these steps.
   1. Let |pose| be a [=new=] {{XRJointPose}} object in the [=relevant realm=] of |session|.
   1. [=Populate the pose=] of |joint| in |baseSpace| at the time represented by |frame| into |pose|, with <code>force emulation</code> set to <code>false</code>.
   1. If |pose| is <code>null</code> return <code>null</code>.
@@ -389,10 +387,6 @@ When this method is invoked on an {{XRFrame}} |frame|, the user agent MUST run t
 
   1. Let |frame| be [=this=].
   1. Let |session| be |frame|'s {{XRFrame/session}} object.
-  1. If |frame|'s [=active=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
-  1. For each |space| in the |spaces| sequence:
-    1. If |space|'s [=XRSpace/session=] is different from |session|, throw an {{InvalidStateError}} and abort these steps.
-  1. If |baseSpace|'s [=XRSpace/session=] is different from |session|, throw an {{InvalidStateError}} and abort these steps.
   1. If the length of |spaces| multiplied by <code>16</code> is larger than the number of elements in |transforms|, throw a {{TypeError}} and abort these steps.
   1. let |offset| be a new number with the initial value of <code>0</code>.
   1. Initialize |pose| as follows:


### PR DESCRIPTION
The checks for "frame's active bollean",  "baseSpace session == this session" and "space's session = this session" are all already included in https://immersive-web.github.io/webxr/#populate-the-pose algorithm that is called as a step in these algorithms. I think these checks are redundant.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jmajnert/webxr-hand-input/pull/97.html" title="Last updated on Jul 18, 2021, 5:03 PM UTC (501c3bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-hand-input/97/2e10665...jmajnert:501c3bf.html" title="Last updated on Jul 18, 2021, 5:03 PM UTC (501c3bf)">Diff</a>