### PR TITLE
fix for WD 20210824

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -414,7 +414,7 @@ When this method is invoked on an {{XRFrame}} |frame|, the user agent MUST run t
 
 </div>
 
-NOTE: if any of the spaces belonging to the same {{XRHand}} return <code>null</null> when [=Populate the pose|populating the pose=], all the spaces of that {{XRHand}} must also return <code>null</null> when [=Populate the pose|populating the pose=]
+NOTE: if any of the spaces belonging to the same {{XRHand}} return <code>null</code> when [=Populate the pose|populating the pose=], all the spaces of that {{XRHand}} must also return <code>null</code> when [=Populate the pose|populating the pose=]
 
 XRJointPose {#xrjointpose-interface}
 -----------


### PR DESCRIPTION
/null should be /code


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr-hand-input/pull/103.html" title="Last updated on Aug 24, 2021, 4:14 PM UTC (69a771e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-hand-input/103/d1f9d2f...himorin:69a771e.html" title="Last updated on Aug 24, 2021, 4:14 PM UTC (69a771e)">Diff</a>