### PR TITLE
Allow generic-hand

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -95,6 +95,7 @@ spec: webxr-1;
     type: dfn; text: input profile name; for: XRInputSource
     type: dfn; text: primary action; for: /
     type: dfn; text: primary squeeze action; for: /
+    type: dfn; text: primary input source; for: /
 spec:infra; type:dfn; text:list
 spec:webxr-ar-module-1; type:enum-value; text:"immersive-ar"
 spec:webidl;
@@ -136,7 +137,7 @@ Physical Hand Input Sources {#physical-hand}
 
 An {{XRInputSource}} is a <dfn>physical hand input source</dfn> if it tracks a physical hand. A [=physical hand input source=] <dfn>supports hand tracking</dfn> if it supports reporting the poses of one or more [=skeleton joints=] defined in this specification.
 
-[=Physical hand input sources=] MUST include the [=XRInputSource/input profile name=] of "generic-hand-select" in their {{XRInputSource/profiles}}.
+[=Physical hand input sources=] MUST include the [=XRInputSource/input profile name=] of either "generic-hand" or "generic-hand-select" in their {{XRInputSource/profiles}}. "generic-hand-select" MUST be included if the input source is a [=primary input source=].
 
 For many [=physical hand input sources=], there can be overlap between the gestures used for the [=primary action=] and the squeeze action. For example, a pinch gesture may indicate both a "select" and "squeeze" event, depending on whether you are interacting with nearby or far away objects. Since content may assume that these are independent events, user agents MAY, instead of surfacing the squeeze action as the [=primary squeeze action=], surface it as an additional "grasp button", using an input profile derived from the "generic-hand-select-grasp" profile.
 


### PR DESCRIPTION
It's unclear to me if we shoudl require "generic-hand" at all times or allow "generic-hand-select" input methods to omit "generic-hand" (thoughts @cabanier?)

Fixes https://github.com/immersive-web/webxr/issues/1358


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr-hand-input/pull/121.html" title="Last updated on Feb 6, 2024, 10:37 PM UTC (bc48acc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-hand-input/121/4a46e82...Manishearth:bc48acc.html" title="Last updated on Feb 6, 2024, 10:37 PM UTC (bc48acc)">Diff</a>